### PR TITLE
ci: Use GitHub Pages GitHub Actions for deployment

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
 
+      - name: Show site directory structure
+        run: tree _site/
+
       - name: Fix permissions if needed
         run: |
           chmod -c -R +rX "_site/" | while read line; do

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -2,24 +2,18 @@
 name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches:
+    - master
+  pull_request:
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Build job
@@ -28,23 +22,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
+
+      - name: Fix permissions if needed
+        run: |
+          chmod -c -R +rX "_site/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
+    name: Deploy site to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Descriptions

This PR implements very similar changes to the CI system as https://github.com/UW-Madison-DSI/open_source_survey_results/pull/1

### Change summary

* Add run trigger for pull_requests to be able to test builds on PRs.
   - Restrict deployment to push events to master only, which correspond to merged PRs.
* Use concurrency to avoid wasting CI time.
* Remove redundant defaults.
* Add file permissions fix check.
* Only escalate permissions on jobs that require them and limit the default permissions to be read only.

This PR will be followed up by a PR to address Issue #7 


## Important

This PR should not be merged until https://github.com/UW-Madison-DSI/ospo.wisc.edu-uw-jekyll-theme/settings/pages is switched over to use deploy from GitHub Actions

![image](https://github.com/user-attachments/assets/f2909361-d70d-4844-90cd-718c23224648)

This needs agreement in advance.