### PR TITLE
fix: Correct NumFOCUS affiliation description

### DIFF
--- a/_pages/partners.md
+++ b/_pages/partners.md
@@ -70,7 +70,7 @@ permalink: /partners
 				<li>
 					<img src="images/partners/numfocus-logo-resized.png" alt="NumFOCUS logo">
 					<h2 class="uw-mini-bar"><a style="text-decoration: none;" href="https://numfocus.org/" target="_blank">NumFOCUS</a></h2>
-					<p>NumFOCUS promotes open practices in research, data, and scientific computing. We are working with Matthew Feikert, a NumFOCUS organizer and key member of the NumFOCUS community. </p>
+					<p>NumFOCUS promotes open practices in research, data, and scientific computing. We are working with Matthew Feickert, DSI researcher and developer of a NumFOCUS Affiliated Project. </p>
 				</li>
 			</div>
 


### PR DESCRIPTION
* Correct name typo.
* Matthew has no formal role or affiliation with NumFOCUS, but is a developer of the NumFOCUS Affiliated Project pyhf.

This PR assumes that PR #8 and PR #9 will be approved and merged, and so only edits source files and not build products.