### PR TITLE
feat: Add Rakefile and add Ruby setup and site build in CI

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -23,11 +23,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore bundle cache
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            gems-
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+
+      - name: Bundle install
+        shell: bash
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+      - name: Build the site
+        run: bundle exec rake build
+        env:
+          JEKYLL_ENV: production
 
       - name: Show site directory structure
         run: tree _site/

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rake/clean'
+
+# If no task given, build
+task default: :build
+
+# Support clean and clobber tasks
+CLEAN << '_site'
+CLOBBER << '_cache' << '.sass-cache'
+
+desc 'Preview on a local machine'
+task :serve do
+  trap('SIGINT') { exit }
+  jekyll 'serve', :incremental, :livereload
+end
+
+desc 'Build on a local machine'
+task :build do
+  jekyll 'build', :verbose, :trace
+end
+
+# See https://github.com/gjtorikian/html-proofer#configuration
+COMMON_OPTIONS = {
+  assume_extension: true,
+  allow_hash_href: true,
+  url_swap: { %r{https://localhost:4000/} => '' }
+}.freeze
+
+LIGHT_OPTIONS = {
+  url_ignore: [
+    'Unknown',
+  ]
+}.freeze
+
+desc 'Check already built site'
+task :checkonly do
+  html_proofer COMMON_OPTIONS, LIGHT_OPTIONS
+end
+
+desc 'Check links and things'
+task check: %i[build checkonly]
+
+desc 'Stronger check for missing options - will show up as warnings on GHA'
+task checkall: :build do
+  html_proofer COMMON_OPTIONS
+end
+
+### Support functions ###
+
+# Run the jekyll command, with arguments
+# (symbols are long options, hashes are long options with arguments)
+def jekyll(*directives)
+  directives.map! do |x|
+    case x
+    when Symbol
+      "--#{x}"
+    when Hash
+      x.map { |k, v| "--#{k}=#{v}" }.join(' ')
+    else x
+    end
+  end
+  sh "jekyll #{directives.join(' ')}"
+end
+
+# Run HTMLProofer
+def html_proofer(*options)
+  require 'html-proofer'
+  begin
+    HTMLProofer.check_directory('./_site', options.inject(:merge)).run
+  rescue RuntimeError => e
+    abort e.message
+  end
+end


### PR DESCRIPTION
* Resolves #11
* Resolves #15

## Description

* Add Rakefile to use in CI and for local builds.
* Add Ruby setup to CI.
* Use Rakefile to build site in CI.
* Add caching of the installed Gems to speedup future site builds.

The `Rakefile` was basically copied from Henry's implimentation for the IRIS-HEP website (https://github.com/iris-hep/iris-hep.github.io/blob/293b76a79e76c1d84d3d448ba2476d3fd0c99767/Rakefile) but I've temporarily removed RuboCop just to get things building tonight.