### PR TITLE
ci: Deploy on all events except pull_requests

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -66,7 +66,7 @@ jobs:
   # Deployment job
   deploy:
     name: Deploy site to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
To allow for redeployments from workflow dispatch deploy on all GitHub event triggers except pull_request.