### PR TITLE
docs: Correct localhost url as baseurl removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sh run.sh
 
 The application will be visible at the following url:
 ```
-http://127.0.0.1:4000/ospo.wisc.edu-uw-jekyll-theme
+http://127.0.0.1:4000
 ```
 
 ### `pixi`
@@ -52,7 +52,7 @@ First install the local Ruby `bundle`
 pixi run install
 ```
 
-and then run any defined task with `pixi run` such as building and serving the website at `http://127.0.0.1:4000/ospo.wisc.edu-uw-jekyll-theme/`
+and then run any defined task with `pixi run`, such as building and serving the website at `http://127.0.0.1:4000`
 
 ```
 pixi run serve

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ospo.wisc.edu-uw-jekyll-theme"
+name = "ospo.wisc.edu"
 version = "0.1.0"
 description = "Website for the University of Wisconsin's Open Source Program Office"
 authors = ["Matthew Feickert <matthew.feickert@wisc.edu>"]


### PR DESCRIPTION
* Remove trailing baseurl as 'baseurl' configuration option removed.
   - Amends https://github.com/UW-Madison-DSI/ospo.wisc.edu/commit/8888962bb53a01b96d94d6247c792ce4a86fca32
* Update pixi project name to match renamed GitHub project.