### PR TITLE
ci: Rename CI workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,11 +1,12 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+name: Deploy website to GitHub pages
 
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
* The workflow builds the environment with bundler, so there is nothing preinstalled beyond the use of the cache.
* Run CI on pull request events when they target the default branch.