### PR TITLE
Converting the video from the Sept 26th event from a link to an embed

### DIFF
--- a/_posts/2024-10-21-AI.html
+++ b/_posts/2024-10-21-AI.html
@@ -10,4 +10,11 @@ categories: Announcements 2024
 
 Panelists included: Paige Bailey, engineering lead for the GenAI Developer Experience team at Google; Will Falcon, AI researcher and CEO of Lightning AI; Dmitry Petrov, CEO and co-founder of Iterative.ai and creator of DVC (Data Version Control); and the panel was moderated by Nhi Lê, Principal at Alpha Intelligence Capital.</p>
 
-<a href="https://mediaspace.wisc.edu/media/t/1_3cowcscu" target="_blank">View the recording here!</a>
+<iframe id="kaltura_player" 
+        src='https://cdnapisec.kaltura.com/p/1660902/embedPlaykitJs/uiconf_id/55063162?iframeembed=true&amp;entry_id=1_3cowcscu&amp;config%5Bprovider%5D=%7B%22widgetId%22%3A%221_36kb23zj%22%7D&amp;config%5Bplayback%5D=%7B%22startTime%22%3A0%7D'  
+        style="width: 576px;height: 324px;border: 0;" 
+        allowfullscreen 
+        webkitallowfullscreen
+        mozAllowFullScreen 
+        allow="autoplay *; fullscreen *; encrypted-media *"  
+        title="Open_Source_Fostering_Innovation_9_26"></iframe>


### PR DESCRIPTION
Just a tiny PR of the change Kyle mentioned in the OSPO Slack. 

Mostly, this was just for my own sake, to ensure I could run the site locally. 