### PR TITLE
fix: Correct grammar and content errors

### DIFF
--- a/_pages/community/profiles/matthew-feickert.md
+++ b/_pages/community/profiles/matthew-feickert.md
@@ -1,37 +1,37 @@
 ---
 layout: profile
 fullname: Matthew Feickert
-headline: Matthew Feickert advances particle physics research through open-source innovation
+headline: Matthew Feickert advances particle physics research through open source innovation
 headshot: matthew-feickert.jpg
 permalink: /community/profiles/matthew-feickert
---- 
+---
 
-Open-source software and particle physics go hand in hand, just ask Matthew Feickert. A postdoctoral research associate at the University of Wisconsin-Madison’s Data Science Institute and a part of the Cranmer Lab and the ATLAS collaboration, Fecikert focuses on data science applications and open-source software for particle physics. Open source has been a prominent tool in Feickert’s career so far, setting a foundation for the software he uses to pursue his research in his field.
+Open source software and particle physics go hand in hand, just ask Matthew Feickert. A research scientist at the University of Wisconsin-Madison's Data Science Institute and a part of the Cranmer Lab and the ATLAS collaboration, Feickert focuses on data science applications and open source software for particle physics. Open source has been a prominent tool in Feickert's career so far, setting a foundation for the software he uses to pursue his research in his field.
 
-“Open-source software has become incredibly core to just my scientific career,” Feickert said. “I really view it as a necessity for doing science.”
+"Open source software has become incredibly core to my scientific career," Feickert said. "I really view it as a necessity for doing science."
 
-Most of the software Feickert used during his Ph.D. at Southern Methodist University was open source and developed by the larger particle physics community, introducing him to the software as he soon became a user, contributor and maintainer. With the tools being able to contribute to a faster and more collaborative research environment, it was a no-brainer for him to use.
+Most of the software Feickert used during his Ph.D. at Southern Methodist University was open source and developed by the larger particle physics community, introducing him to the software as he soon became a user, contributor, and maintainer. With open source tools providing a way to a faster and more collaborative research environment, they were a no-brainer for him to use.
 
-“That was really appealing to me as someone who was interested in the idea of open science in general,” Feickert said. “Being able to then try and bring that back into my own work and see if my community of particle physicists could also contribute to some of these broader tools.” 
+"That was really appealing to me as someone who was interested in the idea of open science in general," Feickert said. "Being able to then try and bring that back into my own work and see if my community of particle physicists could also contribute to some of these broader [scientific open source] tools."
 
-As one of the co-creators and maintainers of pyhf Python – a library under the Scikit-HEP umbrella – Feickert focuses on creating and maintaining a tool used for efficient statistical modeling and inference for particle physics. The library has also been a testing ground for new ways of machine learning by using different tools like automated differentiation or hardware acceleration. Feickert is also currently using MicroBooNE and Belle II collaborations for particle physics. When using these tools, Feickert is able to interact on GitHub with many scientists and students he has not before formally, allowing for a community to grow online. 
- 
-The social aspect of open source is as essential as the technical facets. Whether that be by maintaining the project or being able to see how users implement the code in their lives, Feickert believes it is pertinent to the projects. 
+As one of the co-creators and maintainers of `pyhf` &mdash; a Python library under the Scikit-HEP organization &mdash; Feickert focuses on creating and maintaining a tool used for efficient statistical modeling and inference for particle physics. The library has also been a testing ground for applications of technologies from machine learning like automatic differentiation and hardware acceleration. It has also become a tool used by the broader particle physics community, including the ATLAS, MicroBooNE, and Belle II collaborations. Having not only the source code, but also `pyhf`'s development, be open has also allowed Feickert to interact on GitHub with many scientists and students he has not before formally met, allowing for a community to grow online.
 
-“I don't think that everyone needs to basically be in their operating systems, command line, interface, running scripts or writing code, but just being familiar with what sorts of open-source technologies exist and how those could impact what people are doing or, or even how they're thinking about solutions. I think it can be very powerful,” Feickert said. 
- 
-Ensuring that a community has a blend of people who can drive technical development of the project in addition to those who are able to grow the social community and negotiate agreements on what is best for the projects is essential in helping grow and maintain an open-source project. 
+The social aspect of open source is as essential as the technical facets. Whether that be by maintaining the project or being able to see how users implement the code in their lives, Feickert believes it is pertinent to the projects.
 
-“I think all of the great accomplishments that we've seen in open source in the last decade have come from people acting as communities and having a shared faith, community and trust to try and move those big missions forward,” Feickert said. 
+"I don't think that everyone needs to be in their operating systems's command line interface running scripts or writing code, but just being familiar with what sorts of open source technologies exist and how those could impact what people are doing, or even how they're thinking about solutions, I think can be very powerful," Feickert said.
 
-As UW-Madison is on the cusp of introducing its new Open Source Program Office to the community, there can be so much to offer with integrating open source on campus as major projects and research continue to develop. As one of the top ten research institutions in the country, the new program can help feature impactful open-source projects throughout the university. 
+Ensuring that a community has a blend of people who can drive technical development of the project in addition to those who are able to grow the social community and negotiate agreements on what is best for the projects is essential in helping grow and maintain an open source project.
 
-“The longer that I've been here, I've actually realized that [UW-Madison] is kind of like a sleepy giant in some sense because we actually have a lot of hugely impactful people and projects across the university that have been huge players in open source and have been kind of foundational,” Feickert said.
+"I think all of the great accomplishments that we've seen in open source in the last decade have come from people acting as communities and having a shared faith and trust in that community to try and move those big missions forward," Feickert said.
 
-Educating and providing accessible resources for the Madison community to learn more about open source can be beneficial and empowering for many, regardless of their skill set when it comes to coding. Feickert described it as an analogy of a Swiss Army knife, how this knowledge can allow those to recognize opportunities and be able to contribute to open source in whatever capacity they are capable. 
+As UW-Madison is on the cusp of introducing its new Open Source Program Office to the community, there can be so much to offer with integrating open source on campus as major projects and research continue to develop. As one of the top ten research institutions in the country, the new program can help feature impactful open source projects throughout the university.
 
-“People engaging with this can lead to amazing renaissances,” Feickert said. “I still feel that personally, but I think that on a practical level just having people understand that they have tools readily available to them can help them in their goals.”
+"The longer that I've been here, I've actually realized that [UW-Madison] is kind of like a sleeping giant in some sense because we actually have a lot of hugely impactful people and projects across the university that have been huge players in open source and have been kind of foundational," Feickert said.
 
-Open source can be an empowering tool for both professional data scientists and the rest of the community. Open source can be a rewarding tool to help further software and research in many different areas, as a more prominent stance on it is advancing in Madison. 
+Educating and providing accessible resources for the Madison community to learn more about open source can be beneficial and empowering for many, regardless of their skill set when it comes to coding. Feickert described it as an analogy of a Swiss Army knife, how this knowledge can allow those to recognize opportunities and be able to contribute to open source in whatever capacity they are capable.
 
-“I have found open source to be this huge enabling force in both my technical and social professional life,” Feickert said. “It's been hugely rewarding also through the interactions I've had in open source to now get to work with some of the people who I viewed as heroes or mentors of mine, and I now get to call them colleagues.” 
+"People engaging with this can lead to amazing renaissances," Feickert said. "I still feel that personally, but I think that on a practical level just having people understand that they have tools readily available to them can help them in their goals."
+
+Open source can be an empowering tool for both professional data scientists and the rest of the community. Open source can be a rewarding tool to help further software and research in many different areas, as a more prominent stance on it is advancing in Madison.
+
+"I have found open source to be this huge enabling force in both my technical and social professional life," Feickert said. "It's been hugely rewarding also through the interactions I've had in open source to now get to work with some of the people who I viewed as heroes or mentors of mine, and I now get to call them colleagues."


### PR DESCRIPTION
* Select 'open source' instead of using multiple forms of the phrase.
* Avoid unicode charecters for ASCII symbols.
* Remove erroneous commas.
* Remove double words.
* Correct position at university.
* Correct factual errors about collaborations.
* Correct phrasing of technologies from machine learning.
* Correct transcription errors.

Profile originally added in 93256e796805fa8d0f2fc48e2c7be68d6960f2fd