### PR TITLE
fix: Correct typesetting of 'NumFOCUS'

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -9,7 +9,7 @@ left-column:
       url: https://www.library.wisc.edu/
     - text: CURIOSS
       url: https://curioss.org/
-    - text: NumFocus
+    - text: NumFOCUS
       url: https://numfocus.org/
 
 center-column: 


### PR DESCRIPTION
* The organization is 'NumFOCUS' in all copy.
   - Amends https://github.com/UW-Madison-DSI/ospo.wisc.edu/commit/7246407ef0f6af6567346d5a8b945dcc6dedad13